### PR TITLE
Refactor: Extract SeaORM models into separate entity crate

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1349,6 +1349,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
+name = "entity"
+version = "0.1.0"
+dependencies = [
+ "sea-orm",
+ "serde",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +2641,7 @@ dependencies = [
  "async-graphql",
  "async-trait",
  "chrono",
+ "entity",
  "migration",
  "sea-orm",
  "sea-orm-migration",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["lifebook", "migration"]
+members = ["lifebook", "migration", "entity"]
 resolver = "2"

--- a/src-tauri/entity/Cargo.toml
+++ b/src-tauri/entity/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "entity"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "entity"
+path = "src/lib.rs"
+
+[dependencies]
+sea-orm = { version = "1", features = ["macros"] }
+serde = { version = "1", features = ["derive"] }

--- a/src-tauri/entity/src/book.rs
+++ b/src-tauri/entity/src/book.rs
@@ -1,4 +1,4 @@
-// Infrastructure Layer - Book SeaORMモデル（DBスキーマ）
+// Entity Layer - Book SeaORMモデル（DBスキーマ）
 
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/src-tauri/entity/src/lib.rs
+++ b/src-tauri/entity/src/lib.rs
@@ -1,0 +1,3 @@
+//! Entity Layer - SeaORM Models
+
+pub mod book;

--- a/src-tauri/lifebook/Cargo.toml
+++ b/src-tauri/lifebook/Cargo.toml
@@ -37,3 +37,4 @@ async-trait = "0.1"
 anyhow = "1"
 chrono = "0.4"
 migration = { path = "../migration" }
+entity = { path = "../entity" }

--- a/src-tauri/lifebook/src/infrastructure.rs
+++ b/src-tauri/lifebook/src/infrastructure.rs
@@ -1,3 +1,0 @@
-// Infrastructure Layer - 技術的詳細（SeaORM Models）
-
-pub mod models;

--- a/src-tauri/lifebook/src/infrastructure/models.rs
+++ b/src-tauri/lifebook/src/infrastructure/models.rs
@@ -1,3 +1,0 @@
-// Infrastructure Layer - SeaORM Models
-
-pub mod book;

--- a/src-tauri/lifebook/src/lib.rs
+++ b/src-tauri/lifebook/src/lib.rs
@@ -2,7 +2,6 @@
 
 mod app_state;
 mod database;
-mod infrastructure;
 mod modules;
 mod presentation;
 

--- a/src-tauri/lifebook/src/modules/library/infrastructure/repositories/book.rs
+++ b/src-tauri/lifebook/src/modules/library/infrastructure/repositories/book.rs
@@ -1,9 +1,9 @@
 // Library Infrastructure Layer - Book リポジトリ実装
 
-use crate::infrastructure::models::book;
 use crate::modules::library::domain::{entities::book::Book, repositories::book::BookRepository};
 use crate::modules::shared::domain::errors::DomainError;
 use async_trait::async_trait;
+use entity::book;
 use sea_orm::{ActiveModelTrait, DatabaseConnection, NotSet, Set, entity::prelude::*};
 
 /// BookRepository の SeaORM実装


### PR DESCRIPTION
## Summary
This PR extracts SeaORM model definitions from the infrastructure layer into a separate `entity` crate, aligning with the migration crate pattern.

## Changes
- Created new `entity` crate at `src-tauri/entity/`
- Moved SeaORM model definitions from `infrastructure/models` to entity crate
- Updated workspace configuration to include entity crate
- Updated lifebook dependencies to use entity crate
- Removed old `infrastructure/models` directory
- Updated imports in repository implementation

## Benefits
- Better separation of concerns
- Consistent with migration crate structure
- SeaORM models are now independently managed
- Cleaner project architecture

## Testing
- ✅ `cargo check` passes
- ✅ No linter errors
- ✅ All imports correctly updated