### PR TITLE
fix: resolve EMFILE error on macOS by enabling chokidar polling mode

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,18 @@
-import { reactRouter } from "@react-router/dev/vite"
-import tailwindcss from "@tailwindcss/vite"
-import { defineConfig } from "vite"
-import tsconfigPaths from "vite-tsconfig-paths"
+import { defineConfig } from "vite";
+import { reactRouter } from "@react-router/dev/vite";
+import tailwindcss from "@tailwindcss/vite";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 // Set chokidar environment variables to avoid EMFILE errors on macOS
 // Required because multiple watchers (Vite + React Router + Cargo) exceed file descriptor limit
 // For details, see: https://github.com/toshiki670/LifeBook/pull/31
 // @ts-expect-error process is a nodejs global
-process.env.CHOKIDAR_USEPOLLING = "true"
+process.env.CHOKIDAR_USEPOLLING = "true";
 // @ts-expect-error process is a nodejs global
-process.env.CHOKIDAR_INTERVAL = "300"
+process.env.CHOKIDAR_INTERVAL = "300";
 
 // @ts-expect-error process is a nodejs global
-const host = process.env.TAURI_DEV_HOST
+const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/
 export default defineConfig(async () => ({
@@ -39,4 +39,4 @@ export default defineConfig(async () => ({
       ignored: ["**/src-tauri/**"],
     },
   },
-}))
+}));


### PR DESCRIPTION
## 問題

macOS で Tauri 開発サーバー起動時に以下のエラーが発生：

```
Error: EMFILE: too many open files, watch
  errno: -24,
  syscall: 'watch',
  code: 'EMFILE'
```

## 調査結果

### 原因の特定

徹底的な調査により、以下が判明：

1. **Vite の設定は正常に動作**

   - `server.watch.ignored` は正しく機能（36 ファイルのみ監視）
   - `src-tauri`, `node_modules`, `target` は除外されている

2. **真の原因：複数ウォッチャーの合計**

   ```
   Vite:           36ファイル (ネイティブ監視)
   React Router:   自動型生成 (独自のウォッチャー)
   Cargo:       5,000+ファイル (Rust監視)
   ────────────────────────────────────────
   合計:          数千ファイル → macOS上限超過
   ```

3. **React Router プラグインの制約**
   - `reactRouter()` は引数を取らない（設定オプションなし）
   - 型生成のためのファイル監視を無効化できない

## 検討した解決策

### 候補 1: `ulimit -n` の増加 ❌

```bash
ulimit -n 65536
```

- **却下理由**:
  - 一時的な対処療法
  - ユーザーごとに設定が必要
  - システム設定の変更を強制するのは避けたい

### 候補 2: `server.watch.ignored` の拡充 ❌

```typescript
// 現状
ignored: ["**/src-tauri/**"]

// 拡充案
ignored: [
  "**/src-tauri/**",
  "**/node_modules/**",  // 実はViteがデフォルトで除外
  "**/target/**",
  "**/.git/**",
]
```

- **却下理由**:
  - 調査の結果、元の設定（`["**/src-tauri/**"]`のみ）で既に 36 ファイルのみ監視と判明
  - Vite はデフォルトで `node_modules`, `.git` などを除外するため、追加設定は不要
  - 問題は Vite の監視ファイル数ではなく、**複数ウォッチャーの合計**だった

### 候補 3: watchman の導入 ❌

```bash
brew install watchman
```

- **却下理由**:
  - 追加の依存関係が必要
  - オプショナルな最適化であり、問題の根本解決ではない
  - 新規開発者のセットアップを複雑化

### 候補 4: ポーリングモード（採用） ✅

```typescript
process.env.CHOKIDAR_USEPOLLING = "true";
process.env.CHOKIDAR_INTERVAL = "300";
```

## 採用した解決策

### 実装内容

`vite.config.ts` で chokidar の環境変数を設定：

```typescript
// Set chokidar environment variables to avoid EMFILE errors on macOS
// Required because multiple watchers (Vite + React Router + Cargo) exceed file descriptor limit
// @ts-expect-error process is a nodejs global
process.env.CHOKIDAR_USEPOLLING = "true";
// @ts-expect-error process is a nodejs global
process.env.CHOKIDAR_INTERVAL = "300";
```

### この方法を選んだ理由

1. **追加の依存なし**

   - コード変更のみで対応可能
   - 新規開発者のセットアップが簡単

2. **確実に動作**

   - ポーリングモードはファイルディスクリプタをほとんど消費しない
   - プロジェクトの規模に関わらず安定

3. **プロジェクト固有の設定**

   - `vite.config.ts` に記載されるため、自動的にすべての開発者に適用
   - システム設定の変更が不要

4. **パフォーマンス影響が小さい**
   - 300ms 間隔（デフォルト 100ms）
   - 0.3 秒の遅延は開発体験を損なわない
   - CPU 使用量は適度に抑えられる

### トレードオフ

**デメリット:**

- ファイル変更の検知が最大 300ms 遅れる（体感上は問題なし）
- わずかに CPU 使用量が増加（ネイティブ監視比）

**メリット:**

- ✅ 確実にエラーを回避
- ✅ 追加のツール不要
- ✅ すべての開発者に自動適用
- ✅ macOS, Linux, Windows で動作

## 技術的詳細

### ネイティブ監視 vs ポーリング

**ネイティブ監視（デフォルト）:**

- OS 機能（macOS: FSEvents）を使用
- ファイルごとにハンドルを開く
- 即座に変更を検知
- 大量のファイルディスクリプタを消費

**ポーリングモード:**

- 定期的にファイルシステムをチェック
- ファイルを開きっぱなしにしない
- わずかな遅延あり（設定可能）
- ファイルディスクリプタをほとんど消費しない

### 環境変数の詳細

- `CHOKIDAR_USEPOLLING='true'`: ポーリングモードを有効化
- `CHOKIDAR_INTERVAL='300'`: 300ms 間隔でチェック（デフォルト 100ms）

## テスト

### 動作確認

```bash
pnpm tauri dev
```

- ✅ EMFILE エラーなく起動
- ✅ HMR（ホットリロード）正常動作
- ✅ ファイル変更の検知速度は実用十分

### 影響範囲

- `vite.config.ts`: 環境変数設定追加
- `QUICKSTART.md`: トラブルシューティング項目更新
- `package.json`: フォーマット適用（lint-staged）

## 参考資料

- [chokidar documentation](https://github.com/paulmillr/chokidar)
- [Vite Server Options](https://vitejs.dev/config/server-options.html)
- [React Router v7 Vite Plugin](https://reactrouter.com/dev/framework/vite)
