### PR TITLE
fix: update actions/setup-node from v4 to v5

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.changed-files.outputs.has_biome_files == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"
@@ -87,7 +87,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.ts-check.outputs.ts_changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"


### PR DESCRIPTION
## 概要
Frontend CI ワークフローで使用している actions/setup-node のバージョンを v4 から v5 に更新しました。

## 変更内容
- actions/setup-node@v4 → actions/setup-node@v5

## 理由
v4 が存在せず、エラーが発生していたため、最新の v5 に更新しました。