### PR TITLE
fix: remove unused @ts-expect-error directives in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,12 +6,9 @@ import tsconfigPaths from "vite-tsconfig-paths"
 // Set chokidar environment variables to avoid EMFILE errors on macOS
 // Required because multiple watchers (Vite + React Router + Cargo) exceed file descriptor limit
 // For details, see: https://github.com/toshiki670/LifeBook/pull/31
-// @ts-expect-error process is a nodejs global
 process.env.CHOKIDAR_USEPOLLING = "true"
-// @ts-expect-error process is a nodejs global
 process.env.CHOKIDAR_INTERVAL = "300"
 
-// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST
 
 // https://vite.dev/config/


### PR DESCRIPTION
## 問題
vite.config.tsの3箇所で「Unused '@ts-expect-error' directive」という警告が出ていました。

## 原因
コミットb7a0ca8でEMFILEエラー修正のためにchokidar設定をアクティブ化した際、コメントアウトされていたコードから`@ts-expect-error`もそのまま含めてしまいました。

しかし、プロジェクト作成時から存在する`tsconfig.node.json`により、`vite.config.ts`はNode.js環境として扱われており、`process`オブジェクトは正しく型付けされています。そのため、`@ts-expect-error`は最初から不要でした。

## 修正内容
- vite.config.tsから3箇所の不要な`@ts-expect-error`コメント行を削除

## 影響
- TypeScript警告が解消されます
- コードの動作には影響ありません（コメント行のみ削除）
- `process.env`への代入と参照は正常に動作し続けます