### PR TITLE
Add Rust target directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ dist-ssr
 
 # Generated GraphQL schema
 schema.graphql
+
+# Rust
+target/


### PR DESCRIPTION
Add Rust target/ directory to .gitignore to prevent committing build artifacts