### PR TITLE
Add delete book functionality with GraphQL mutation

### DIFF
--- a/src/features/books/delete/api/checkBookExists.ts
+++ b/src/features/books/delete/api/checkBookExists.ts
@@ -1,0 +1,15 @@
+import { apolloClient } from "~/lib/apollo-client"
+import { CheckBookExistsDocument } from "./queries.generated"
+
+/**
+ * 指定した書籍が存在するか確認
+ */
+export async function checkBookExists(id: number): Promise<boolean> {
+  const result = await apolloClient.query({
+    query: CheckBookExistsDocument,
+    variables: { id },
+    fetchPolicy: "network-only",
+  })
+
+  return Boolean(result.data?.library?.book)
+}

--- a/src/features/books/delete/api/deleteBook.ts
+++ b/src/features/books/delete/api/deleteBook.ts
@@ -1,0 +1,34 @@
+import { apolloClient } from "~/lib/apollo-client"
+import { DeleteBookDocument } from "./mutations.generated"
+
+/**
+ * 書籍を削除
+ */
+export async function deleteBook(id: number) {
+  try {
+    const result = await apolloClient.mutate({
+      mutation: DeleteBookDocument,
+      variables: { id },
+    })
+
+    if (result.error) {
+      return {
+        error: result.error,
+      }
+    }
+
+    const fetchResult = result as { errors?: readonly unknown[] }
+    if (fetchResult.errors && fetchResult.errors.length > 0) {
+      return {
+        error: new Error("GraphQL error occurred"),
+      }
+    }
+
+    return { success: true }
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error : new Error("Failed to delete book"),
+    }
+  }
+}
+

--- a/src/features/books/delete/api/deleteBook.ts
+++ b/src/features/books/delete/api/deleteBook.ts
@@ -31,4 +31,3 @@ export async function deleteBook(id: number) {
     }
   }
 }
-

--- a/src/features/books/delete/api/mutations.generated.ts
+++ b/src/features/books/delete/api/mutations.generated.ts
@@ -1,0 +1,14 @@
+// @ts-nocheck
+import type * as Types from '../../../../generated/graphql';
+
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+export type DeleteBookMutationVariables = Types.Exact<{
+  id: Types.Scalars['Int']['input'];
+}>;
+
+
+export type DeleteBookMutation = { __typename?: 'MutationRoot', library: { __typename?: 'BookMutation', deleteBook: boolean } };
+
+
+export const DeleteBookDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteBook"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"library"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteBook"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]}}]} as unknown as DocumentNode<DeleteBookMutation, DeleteBookMutationVariables>;
+

--- a/src/features/books/delete/api/mutations.generated.ts
+++ b/src/features/books/delete/api/mutations.generated.ts
@@ -11,4 +11,3 @@ export type DeleteBookMutation = { __typename?: 'MutationRoot', library: { __typ
 
 
 export const DeleteBookDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteBook"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"library"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteBook"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]}}]} as unknown as DocumentNode<DeleteBookMutation, DeleteBookMutationVariables>;
-

--- a/src/features/books/delete/api/mutations.graphql
+++ b/src/features/books/delete/api/mutations.graphql
@@ -1,0 +1,9 @@
+#import "../../shared/fragments/book.graphql"
+
+mutation DeleteBook($id: Int!) {
+  library {
+    deleteBook(id: $id)
+  }
+}
+
+

--- a/src/features/books/delete/api/mutations.graphql
+++ b/src/features/books/delete/api/mutations.graphql
@@ -5,5 +5,3 @@ mutation DeleteBook($id: Int!) {
     deleteBook(id: $id)
   }
 }
-
-

--- a/src/features/books/delete/api/queries.generated.ts
+++ b/src/features/books/delete/api/queries.generated.ts
@@ -1,0 +1,13 @@
+// @ts-nocheck
+import type * as Types from '../../../../generated/graphql';
+
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
+export type CheckBookExistsQueryVariables = Types.Exact<{
+  id: Types.Scalars['Int']['input'];
+}>;
+
+
+export type CheckBookExistsQuery = { __typename?: 'QueryRoot', library: { __typename?: 'BookQuery', book?: { __typename?: 'BookDto', id: number } | null } };
+
+
+export const CheckBookExistsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"CheckBookExists"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"library"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"book"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]}}]} as unknown as DocumentNode<CheckBookExistsQuery, CheckBookExistsQueryVariables>;

--- a/src/features/books/delete/api/queries.graphql
+++ b/src/features/books/delete/api/queries.graphql
@@ -1,0 +1,7 @@
+query CheckBookExists($id: Int!) {
+  library {
+    book(id: $id) {
+      id
+    }
+  }
+}

--- a/src/features/books/delete/page.tsx
+++ b/src/features/books/delete/page.tsx
@@ -1,0 +1,102 @@
+import { Form, redirect, useNavigate, useNavigation } from "react-router"
+import { Alert, AlertDescription } from "~/components/ui/alert"
+import { Button } from "~/components/ui/button"
+import {
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog"
+import type { Route } from "./+types/page"
+import { getBook } from "../detail/api/getBook"
+import { deleteBook } from "./api/deleteBook"
+
+export function meta() {
+  return [{ title: "Delete Book - LifeBook" }]
+}
+
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
+  if (!params.id) {
+    throw new Response("Book ID is required", { status: 400 })
+  }
+
+  const book = await getBook(Number.parseInt(params.id, 10))
+
+  if (!book) {
+    throw new Response("Book not found", { status: 404 })
+  }
+
+  return { book }
+}
+
+export async function clientAction({ params }: Route.ActionArgs) {
+  if (!params.id) {
+    return {
+      success: false,
+      error: "Book ID is required",
+    }
+  }
+
+  const id = Number.parseInt(params.id, 10)
+
+  if (!Number.isInteger(id)) {
+    return {
+      success: false,
+      error: "Book ID is invalid",
+    }
+  }
+
+  const result = await deleteBook(id)
+
+  if (result.error) {
+    return {
+      success: false,
+      error: result.error.message || "Failed to delete book",
+    }
+  }
+
+  return redirect("/books")
+}
+
+export default function DeleteBook({ loaderData, actionData }: Route.ComponentProps) {
+  const { book } = loaderData
+  const navigate = useNavigate()
+  const navigation = useNavigation()
+  const isSubmitting = navigation.state === "submitting"
+
+  return (
+    <div className="space-y-6">
+      <DialogHeader>
+        <DialogTitle>書籍を削除しますか？</DialogTitle>
+        <DialogDescription>
+          <p className="text-sm">
+            「{book.title}」を削除すると元に戻せません。この操作を続行しますか？
+          </p>
+        </DialogDescription>
+      </DialogHeader>
+
+      {actionData?.success === false && actionData.error && (
+        <Alert variant="destructive">
+          <AlertDescription>{actionData.error}</AlertDescription>
+        </Alert>
+      )}
+
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => navigate("/books")}
+          disabled={isSubmitting}
+        >
+          キャンセル
+        </Button>
+        <Form method="post">
+          <Button type="submit" variant="destructive" disabled={isSubmitting}>
+            {isSubmitting ? "削除中..." : "削除する"}
+          </Button>
+        </Form>
+      </DialogFooter>
+    </div>
+  )
+}
+

--- a/src/features/books/delete/page.tsx
+++ b/src/features/books/delete/page.tsx
@@ -1,14 +1,9 @@
 import { Form, redirect, useNavigate, useNavigation } from "react-router"
 import { Alert, AlertDescription } from "~/components/ui/alert"
 import { Button } from "~/components/ui/button"
-import {
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "~/components/ui/dialog"
+import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "~/components/ui/dialog"
 import type { Route } from "./+types/page"
-import { getBook } from "../detail/api/getBook"
+import { checkBookExists } from "./api/checkBookExists"
 import { deleteBook } from "./api/deleteBook"
 
 export function meta() {
@@ -20,13 +15,19 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
     throw new Response("Book ID is required", { status: 400 })
   }
 
-  const book = await getBook(Number.parseInt(params.id, 10))
+  const id = Number.parseInt(params.id, 10)
 
-  if (!book) {
+  if (!Number.isInteger(id)) {
+    throw new Response("Book ID is invalid", { status: 400 })
+  }
+
+  const exists = await checkBookExists(id)
+
+  if (!exists) {
     throw new Response("Book not found", { status: 404 })
   }
 
-  return { book }
+  return { bookId: id }
 }
 
 export async function clientAction({ params }: Route.ActionArgs) {
@@ -59,7 +60,7 @@ export async function clientAction({ params }: Route.ActionArgs) {
 }
 
 export default function DeleteBook({ loaderData, actionData }: Route.ComponentProps) {
-  const { book } = loaderData
+  const { bookId } = loaderData
   const navigate = useNavigate()
   const navigation = useNavigation()
   const isSubmitting = navigation.state === "submitting"
@@ -70,7 +71,7 @@ export default function DeleteBook({ loaderData, actionData }: Route.ComponentPr
         <DialogTitle>書籍を削除しますか？</DialogTitle>
         <DialogDescription>
           <p className="text-sm">
-            「{book.title}」を削除すると元に戻せません。この操作を続行しますか？
+            ID {bookId} の書籍を削除すると元に戻せません。この操作を続行しますか？
           </p>
         </DialogDescription>
       </DialogHeader>
@@ -99,4 +100,3 @@ export default function DeleteBook({ loaderData, actionData }: Route.ComponentPr
     </div>
   )
 }
-

--- a/src/features/books/list/BookCard.tsx
+++ b/src/features/books/list/BookCard.tsx
@@ -1,14 +1,14 @@
-import { Form, Link } from "react-router"
+import { Link } from "react-router"
 import { Button } from "~/components/ui/button"
 import { Card, CardContent } from "~/components/ui/card"
 import type { BookCardFragment } from "../shared/fragments/book.generated"
 
 interface BookCardProps {
   book: BookCardFragment
-  isSubmitting: boolean
+  isNavigating: boolean
 }
 
-export function BookCard({ book, isSubmitting }: BookCardProps) {
+export function BookCard({ book, isNavigating }: BookCardProps) {
   return (
     <Card>
       <CardContent className="pt-6">
@@ -17,13 +17,11 @@ export function BookCard({ book, isSubmitting }: BookCardProps) {
             <h3 className="text-xl font-semibold hover:underline">{book.title}</h3>
             {book.author && <p className="text-muted-foreground mt-1">著者: {book.author}</p>}
           </Link>
-          <Form method="post" className="ml-4">
-            <input type="hidden" name="intent" value="delete" />
-            <input type="hidden" name="id" value={book.id} />
-            <Button type="submit" variant="destructive" size="sm" disabled={isSubmitting}>
-              {isSubmitting ? "削除中..." : "削除"}
+          <div className="ml-4">
+            <Button asChild variant="destructive" size="sm" disabled={isNavigating}>
+              <Link to={`/books/${book.id}/delete`}>削除</Link>
             </Button>
-          </Form>
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/features/books/list/BookList.tsx
+++ b/src/features/books/list/BookList.tsx
@@ -9,7 +9,9 @@ interface BookListProps {
 export function BookList({ books }: BookListProps) {
   const navigation = useNavigation()
   const isLoading = navigation.state === "loading"
-  const isSubmitting = navigation.state === "submitting"
+  const deleteTargetMatch = navigation.location?.pathname?.match(/^\/books\/(\d+)\/delete$/)
+  const deletingId = deleteTargetMatch ? Number.parseInt(deleteTargetMatch[1], 10) : null
+  const isNavigatingToDelete = navigation.state !== "idle" && Number.isInteger(deletingId)
 
   if (isLoading) {
     return <p className="text-muted-foreground">読み込み中...</p>
@@ -25,9 +27,10 @@ export function BookList({ books }: BookListProps) {
 
   return (
     <div className="space-y-4">
-      {books.map((book) => (
-        <BookCard key={book.id} book={book} isSubmitting={isSubmitting} />
-      ))}
+      {books.map((book) => {
+        const isNavigating = isNavigatingToDelete && deletingId === book.id
+        return <BookCard key={book.id} book={book} isNavigating={isNavigating} />
+      })}
     </div>
   )
 }

--- a/src/features/books/list/page.tsx
+++ b/src/features/books/list/page.tsx
@@ -33,6 +33,8 @@ export default function Books({ loaderData }: Route.ComponentProps) {
   const location = useLocation()
   const navigate = useNavigate()
   const isCreateModalOpen = location.pathname === "/books/create"
+  const isDeleteModalOpen = /^\/books\/\d+\/delete$/.test(location.pathname)
+  const isModalOpen = isCreateModalOpen || isDeleteModalOpen
 
   return (
     <>
@@ -62,7 +64,7 @@ export default function Books({ loaderData }: Route.ComponentProps) {
       </div>
 
       <Dialog
-        open={isCreateModalOpen}
+        open={isModalOpen}
         onOpenChange={(open) => {
           if (!open) {
             // モーダルを閉じる際は一覧ページに戻る

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -5,6 +5,7 @@ export default [
     index("features/dashboard/page.tsx"),
     route("books", "features/books/list/page.tsx", [
       route("create", "features/books/create/page.tsx"),
+      route(":id/delete", "features/books/delete/page.tsx"),
     ]),
     route("books/:id", "features/books/detail/page.tsx", [
       route("edit", "features/books/update/page.tsx"),


### PR DESCRIPTION
- Implemented `deleteBook` API function to handle book deletion.
- Created GraphQL mutation for deleting a book.
- Added a new page for confirming book deletion with a dialog.
- Updated `BookCard` to link to the delete page instead of using a form.
- Enhanced `BookList` to manage navigation state during deletion.
- Adjusted routing to include delete functionality for books.